### PR TITLE
Add .editorconfig and indentation health check - Closes #1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,25 @@
 [*.lua]
 indent_size = 2
 indent_style = space
+
+# Consistent indentation for Godot projects.
+# Copy and paste this in your own.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# GDScript
+[*.gd]
+indent_style = space
+indent_size = 4
+
+# C#
+[*.cs]
+indent_style = space
+indent_size = 4
+

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Neovim plugin for Godot game development, using Neovim as an external editor. Pr
 
 ## Requirements
 
-- Neovim 0.9+  
-- Godot 4.x+ with TCP LSP enabled  
-- `nvim-lspconfig`  
-- `nvim-dap` and `nvim-dap-ui` for debugging  
-- `nvim-treesitter`  
+- Neovim 0.9+
+- Godot 4.x+ with TCP LSP enabled
+- `nvim-lspconfig`
+- `nvim-dap` and `nvim-dap-ui` for debugging
+- `nvim-treesitter`
 - Windows users must have [`ncat`](https://nmap.org/ncat/) in PATH
 - Optional C# support requires:
   - .NET SDK (dotnet)
@@ -64,7 +64,7 @@ require("godotdev").setup({
 Below are the recommended settings for configuring the Godot editor for optimal integration with Neovim as your external editor. To access these settings, make sure that the **Advanced Settings switch is enabled** at the top of the **Editor Settings dialog**.
 
 - `Editor Settings > Text Editor > Behavior > Auto Reload Scripts on External Change`
-   
+
    <details><summary>Show Screenshot -> Godot Editor Settings</summary><img src="assets/godot-editor-auto-reload-script.png"></details>
 - `Editor Settings > Interface > Editor > Save on Focus Loss`
 
@@ -95,7 +95,7 @@ A workaround is to to create a small script which launches the file in Neovim.
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
     ```
 1. Configure Godot: `Editor > Editor Settings > Text Editor > External` with full path and `{file} {line} {col}`.
-   
+
    <details><summary>Show Screenshot -> Godot Editor Settings</summary><img src="assets/godot-editor-settings-for-neovim.png"></details>
 
 1. To make this work you always need to start Neovim like this:
@@ -162,7 +162,7 @@ A workaround is to to create a small script which launches the file in Neovim.
 - `<leader>dB` -> Conditional breakpoint
 
 ### DAP UI
-- `<leader>du` -> , Toggle UI 
+- `<leader>du` -> , Toggle UI
 - `<leader>dr` -> , Open REPL
 
 ## C# Installation Support
@@ -172,3 +172,15 @@ A workaround is to to create a small script which launches the file in Neovim.
   - .NET SDK (`dotnet`)
   - C# LSP server (`csharp-ls` or `omnisharp`)
   - Debugger (`netcoredbg`)
+
+## Indentation
+
+Godot expects **spaces, 4 per indent** (for both GDScript and C#).
+If you see diagnostics like:
+```
+Used tab character for indentation instead of space as used before in the file. [-1] [-1]
+```
+You should configure indentation properly.
+It's recommend adding an [`.editorconfig`](./.editorconfig) to your project.
+
+For more info: `:help godotdev-indent`

--- a/doc/godotdev.txt
+++ b/doc/godotdev.txt
@@ -130,6 +130,29 @@ Optional C# support:
 - netcoredbg debugger
 
 ==============================================================================
+INDENTATION                                             *godotdev-indent*
+
+Godot (both GDScript and C#) expects **spaces, 4 per indent**.
+If you use tabs, the LSP often reports this diagnostic:
+
+    Used tab character for indentation instead of space as used before in the file. [-1] [-1]
+
+To fix this, you should use an `.editorconfig` file. Godot, Neovim
+(via editorconfig plugins), VSCode, and Rider all respect this.
+
+Example `.editorconfig`:
+
+    [*.gd]
+    indent_style = space
+    indent_size = 4
+
+    [*.cs]
+    indent_style = space
+    indent_size = 4
+
+See also: `:checkhealth godotdev`
+
+==============================================================================
 License                                           *godotdev-license*
 
 MIT

--- a/doc/tags
+++ b/doc/tags
@@ -2,6 +2,7 @@ godotdev	godotdev.txt	/*godotdev*
 godotdev-checkhealth	godotdev.txt	/*godotdev-checkhealth*
 godotdev-configuration	godotdev.txt	/*godotdev-configuration*
 godotdev-external	godotdev.txt	/*godotdev-external*
+godotdev-indent	godotdev.txt	/*godotdev-indent*
 godotdev-intro	godotdev.txt	/*godotdev-intro*
 godotdev-keymaps	godotdev.txt	/*godotdev-keymaps*
 godotdev-license	godotdev.txt	/*godotdev-license*

--- a/lua/godotdev/health.lua
+++ b/lua/godotdev/health.lua
@@ -46,6 +46,23 @@ local function has_exe(name)
   return vim.fn.executable(name) == 1
 end
 
+local function check_indent()
+  health.start("Indentation")
+
+  local handle = io.popen("grep -P '\t' -R --include='*.gd' --include='*.cs' . 2>/dev/null | head -n 1")
+  if handle then
+    local result = handle:read("*a")
+    handle:close()
+    if result ~= "" then
+      health.warn(
+        "Mixed indentation detected (tabs found in .gd or .cs files). Godot expects spaces, 4 per indent. See :help godotdev-indent"
+      )
+    else
+      health.ok("Indentation style looks consistent (no tabs in .gd or .cs files).")
+    end
+  end
+end
+
 function M.check()
   health.start("Godotdev.nvim")
 
@@ -132,6 +149,7 @@ Make sure the Godot editor is running with LSP server enabled.
   else
     health.info("ℹ️ C# checks skipped (csharp=false)")
   end
-end
 
+  check_indent()
+end
 return M


### PR DESCRIPTION
## Fix indentation diagnostics: add .editorconfig, health check, docs

### Description:
This PR addresses the recurring diagnostic error in Godot projects:
```
Used tab character for indentation instead of space as used before in the file. [-1] [-1]
```
Issue: #1 

### Changes:
- Added `.editorconfig` to enforce spaces, 4 per indent for `.gd` and `.cs` files.
- Added `:help godotdev-indent` documenting the issue + solution.
- Extended `:checkhealth godotdev` to warn if tabs are found in project files.
- Updated `README` with an Indentation section + link to `.editorconfig`.

### Why:

- Godot requires spaces (4) for indentation in both GDScript and C#.
- Tabs cause noisy diagnostics and inconsistent formatting.
- A default `.editorconfig` makes sure all editors follow the same rules.

### Testing:

- Ran `:checkhealth godotdev` with mixed indentation → warning shown.
- Clean project with `.editorconfig` applied → no warning.
- Verified help docs available with `:help godotdev-indent`.

**This makes indentation consistent for everyone using the plugin.**