### PR TITLE
fix(docs): fall back to direct URL when page verification is rate-lim…

### DIFF
--- a/lua/godotdev/docs.lua
+++ b/lua/godotdev/docs.lua
@@ -54,7 +54,22 @@ function M.open(symbol, renderer)
 
   fetch.resolve_doc_url(resolved_symbol, function(url, _)
     if not url then
-      common.show_feedback(("Could not find Godot docs for `%s`."):format(resolved_symbol))
+      -- Rate-limited or network error from docs.godotengine.org.
+      -- Fall back to trying RST from GitHub directly, bypassing
+      -- the HTML page verification that failed.
+      local page_url = ("%s/classes/class_%s.html"):format(
+        common.build_base_url(),
+        common.class_slug(resolved_symbol)
+      )
+      if chosen_renderer == "browser" then
+        render.open_browser(page_url)
+        return
+      end
+      if chosen_renderer == "buffer" then
+        open_from_rst(resolved_symbol, page_url, "buffer")
+        return
+      end
+      open_from_rst(resolved_symbol, page_url, "float")
       return
     end
 

--- a/tests/spec_docs_render.lua
+++ b/tests/spec_docs_render.lua
@@ -312,4 +312,101 @@ return {
       h.assert_truthy(messages[1]:match("Could not find Godot docs for `NotARealSymbol`") ~= nil)
     end,
   },
+  {
+    name = "docs render from RST when HTML page verification is rate-limited",
+    run = function()
+      h.clear_module("godotdev.docs")
+      local docs = require("godotdev.docs")
+
+      local html_url = "https://docs.godotengine.org/en/stable/classes/class_node.html"
+      local index_url = "https://docs.godotengine.org/en/stable/classes/index.html"
+      local rst_url = "https://raw.githubusercontent.com/godotengine/godot-docs/master/classes/class_node.rst"
+
+      h.with_package("godotdev", {
+        opts = {
+          docs = {
+            renderer = "buffer",
+            version = "stable",
+            language = "en",
+            source_ref = "master",
+            buffer = { position = "current" },
+          },
+        },
+      }, function()
+        h.with_field(vim.fn, "executable", function(name)
+          if name == "curl" then
+            return 1
+          end
+          return vim.fn.executable(name)
+        end, function()
+          with_mock_system({
+            -- Page HTML and index both fail (rate-limit)
+            [html_url] = { code = 1, stdout = "", stderr = "curl: (22) The requested URL returned error: 429" },
+            [index_url] = { code = 1, stdout = "", stderr = "curl: (22) The requested URL returned error: 429" },
+            -- RST source from GitHub succeeds
+            [rst_url] = { code = 0, stdout = "Node\n====\n\nNode is the base class.\n", stderr = "" },
+          }, function()
+            docs.open("Node", "buffer")
+            vim.wait(50)
+            local buf = vim.api.nvim_get_current_buf()
+            local name = vim.api.nvim_buf_get_name(buf)
+            local lines = vim.api.nvim_buf_get_lines(buf, 0, 4, false)
+
+            h.assert_truthy(name:match("godotdev://docs/node") ~= nil)
+            h.assert_equal(lines[1], "# Node")
+          end)
+        end)
+      end)
+    end,
+  },
+  {
+    name = "docs fall back to browser when RST fetch also fails after rate-limit",
+    run = function()
+      h.clear_module("godotdev.docs")
+      local docs = require("godotdev.docs")
+
+      local opened_url
+      local html_url = "https://docs.godotengine.org/en/stable/classes/class_node.html"
+      local index_url = "https://docs.godotengine.org/en/stable/classes/index.html"
+      local rst_url = "https://raw.githubusercontent.com/godotengine/godot-docs/master/classes/class_node.rst"
+
+      h.with_package("godotdev", {
+        opts = {
+          docs = {
+            renderer = "float",
+            fallback_renderer = "browser",
+            version = "stable",
+            language = "en",
+            source_ref = "master",
+          },
+        },
+      }, function()
+        h.with_field(vim.fn, "executable", function(name)
+          if name == "curl" then
+            return 1
+          end
+          return vim.fn.executable(name)
+        end, function()
+          with_mock_system({
+            -- Page HTML, index, and RST all fail
+            [html_url] = { code = 1, stdout = "", stderr = "curl: (22) The requested URL returned error: 429" },
+            [index_url] = { code = 1, stdout = "", stderr = "curl: (22) The requested URL returned error: 429" },
+            [rst_url] = { code = 1, stdout = "", stderr = "fetch failed" },
+          }, function()
+            h.with_field(vim.ui, "open", function(url)
+              opened_url = url
+              return true
+            end, function()
+              docs.open("Node", "float")
+              vim.wait(50, function()
+                return opened_url ~= nil
+              end)
+            end)
+          end)
+        end)
+      end)
+
+      h.assert_equal(opened_url, html_url)
+    end,
+  },
 }


### PR DESCRIPTION
## Summary

Fix `:GodotDocs` (and related commands) failing completely when `docs.godotengine.org` rate-limits or is unreachable — even though the RST documentation source on GitHub is perfectly reachable.

## Details

### Problem

`M.open()` in `lua/godotdev/docs.lua` calls `fetch.resolve_doc_url()` which **always** fetches HTML from `docs.godotengine.org` to verify the page exists before attempting the RST source fetch. When that host returns HTTP 429 (rate limit):

1. The direct page HTML fetch fails
2. `fetch_index()` is called as fallback — but it **also** hits `docs.godotengine.org`
3. Both fail → `callback(nil, nil)` → `M.open()` shows "Could not find Godot docs" and **aborts**

The RST source fetch (`fetch_markdown()` → `raw.githubusercontent.com/godotengine/godot-docs`) is **never reached**, even though it's on a completely different domain and works fine.

### Fix

In `M.open()` (`lua/godotdev/docs.lua`): when `resolve_doc_url()` returns `nil` (rate-limited / network error), instead of showing an error and aborting, **bypass the HTML verification entirely** and proceed directly to the RST source:

1. Construct the page URL from `common.build_base_url()` + `common.class_slug()`
2. For browser renderer → open the URL directly
3. For buffer/float → call `open_from_rst()` which fetches RST from GitHub via `fetch_markdown()`
4. If RST also fails → the existing `fallback_renderer` logic handles the fallback to browser

This mirrors the proven approach used in real-world setups where `docs.godotengine.org` aggressively rate-limits shared IPs but

## ✅ Checklist
- [x ] Tested in **Godot version**: 4.6.3
- [x ] Tested in **Neovim version**: v0.12.3
- [ x] Tested on **OS / Terminal app**: 24.04.1-Ubuntu / gnome-terminal
- [x ] Code follows plugin style guidelines
- [x ] Documentation updated (if needed)

## 📷 Screenshots (if applicable)
<img width="3819" height="1911" alt="image" src="https://github.com/user-attachments/assets/336152d5-877c-4963-b1a2-01f4aad799c9" />

## 🧩 Related Issues
#40 [40 Bug: :GodotDocs fails completely when docs.godotengine.org rate-limits (HTTP 429)](https://github.com/Mathijs-Bakker/godotdev.nvim/issues/40) 
